### PR TITLE
Use modalDialog and proper includeMD parameters to avoid layout issue

### DIFF
--- a/server-core.R
+++ b/server-core.R
@@ -6,6 +6,22 @@ library('pheatmap')
 library('RColorBrewer')
 library('networkD3')
 
+# render .md files to html on-the-fly
+includeMD = function(file) {
+  return(markdownToHTML(file, options = c(''), stylesheet = ''))
+}
+
+# render .Rmd files to html on-the-fly
+includeRmd = function(path) {
+  # shiny:::dependsOnFile(path)
+  contents = paste(readLines(path, warn = FALSE), collapse = '\n')
+  # do not embed image or add css
+  html = knit2html(text = contents, fragment.only = TRUE,
+                   quiet = TRUE, options = '', stylesheet = '')
+  Encoding(html) = 'UTF-8'
+  HTML(html)
+}
+
 # compute standard (FP2) fingerprint and return matrix for Java molecular object
 calcStandardFP = function (molecules, depth = 6L,
                            size = 1024L, silent = TRUE) {

--- a/server.R
+++ b/server.R
@@ -24,6 +24,22 @@ shinyServer(function(input, output, session) {
   crlist = c('auc' = 'AUC', 'acc' = 'Accuracy', 'bedroc' = 'BEDROC',
              'mcc' = 'ThresMCC', 'f' = 'ThresF')
 
+  observeEvent(input$smiles, {
+    showModal(modalDialog(
+      title = "Submit Single Query Compound",
+      HTML(includeMD('help/smiles.md')),
+      easyClose = TRUE
+    ))
+  })
+
+  observeEvent(input$uploadfile, {
+    showModal(modalDialog(
+      title = "Upload Query Compounds",
+      HTML(includeMD('help/upload.md')),
+      easyClose = TRUE
+    ))
+  })
+
   calcPredDF = reactive({
 
     if ( input$inputsmi == '' & is.null(input$file1) ) {

--- a/ui-core.R
+++ b/ui-core.R
@@ -16,39 +16,3 @@ xn.textInput = function (inputId, label, value = '', placeholder = '') {
   tagList(tags$label(label, `for` = inputId),
           tags$input(id = inputId, type = 'text', value = value, placeholder = placeholder))
 }
-
-# render .md files to html on-the-fly
-includeMD = function(file) {
-  return(markdownToHTML(file))
-}
-
-# render .Rmd files to html on-the-fly
-includeRmd = function(path) {
-  # shiny:::dependsOnFile(path)
-  contents = paste(readLines(path, warn = FALSE), collapse = '\n')
-  # do not embed image or add css
-  html = knit2html(text = contents, fragment.only = TRUE, quiet = TRUE)
-  Encoding(html) = 'UTF-8'
-  HTML(html)
-}
-
-# Bootstrap 3 popup help modal
-# Modified from Vincent Nijs's Radiant code:
-# https://github.com/vnijs/radiant/blob/33f9ba81153d028c2c7ad7d7221f346072a84b2b/inst/base/radiant.R#L350
-popHelp = function(modal_title, link, help_file) {
-  sprintf("<div class='modal fade' id='%s' tabindex='-1' role='dialog' aria-labelledby='%s_label' aria-hidden='true'>
-          <div class='modal-dialog'>
-          <div class='modal-content'>
-          <div class='modal-header'>
-          <button type='button' class='close' data-dismiss='modal' aria-label='Close'><span aria-hidden='true'>&times;</span></button>
-          <h4 class='modal-title' id='%s_label'>%s</h4>
-          </div>
-          <div class='modal-body'>%s
-          </div>
-          </div>
-          </div>
-          </div>
-          <i title='Help' class='fa fa-question' data-toggle='modal' data-target='#%s'></i>",
-          link, link, link, modal_title, help_file, link) %>%
-    enc2utf8 %>% HTML
-}

--- a/ui.R
+++ b/ui.R
@@ -12,11 +12,10 @@ shinyUI(navbarPage(title = 'TargetNet',
 
                    tabPanel(title = 'Home',
 
-                            tags$style(type = "text/css", "body, .footnotes, code { font-size: 14px !important; }"),
                             tags$style(type = "text/css", ".tab-content { padding-top: 50px; }"),
 
                             fluidRow(
-                              column(width = 6, offset = 3,
+                              column(width = 5, offset = 5,
                                      tags$br(), tags$br(), tags$br(),
                                      tags$br(), tags$br(), tags$br(),
                                      tags$br(), tags$br(),
@@ -29,11 +28,11 @@ shinyUI(navbarPage(title = 'TargetNet',
 
                             fluidRow(
 
-                              column(width = 12, offset = 0,
+                              column(width = 9, offset = 3,
 
                                      fluidRow(
 
-                                       column(width = 9, offset = 0,
+                                       column(width = 7, offset = 0,
                                               textInput(inputId = 'inputsmi',
                                                         label = '',
                                                         value = '',
@@ -41,7 +40,7 @@ shinyUI(navbarPage(title = 'TargetNet',
                                                         width = '100%')
                                        ),
 
-                                       column(width = 3, offset = 0,
+                                       column(width = 2, offset = 0,
                                               tags$div(class = 'netbutton', # use this div as a wrapper for the next css hack to vertical align the button ...
                                                        xn.actionButton('netButtonSMILE', 'Netting', icon('search')),
                                                        tags$style(type = 'text/css', 'div.netbutton { padding-top:20px; }')
@@ -55,9 +54,9 @@ shinyUI(navbarPage(title = 'TargetNet',
 
                             fluidRow(
 
-                              column(width = 12, offset = 0,
+                              column(width = 9, offset = 3,
                                      fluidRow(
-                                       column(width = 5, offset = 0,
+                                       column(width = 3, offset = 0,
                                               tags$div(class = 'longselect', # use this div as a wrapper for the next css hack to make the bottom space large enough when the options expand ...
                                                        selectInput('criterion', 'Include models with:',
                                                                    c('AUC >=' = 'auc',
@@ -69,7 +68,7 @@ shinyUI(navbarPage(title = 'TargetNet',
                                               ),
                                               tags$style(type = 'text/css', 'div.longselect { margin-top: 10px; margin-bottom:180px; }')
                                        ),
-                                       column(width = 5, offset = 0,
+                                       column(width = 3, offset = 0,
                                               tags$div(class = 'thresholdslider', # use this div as a wrapper for the next css hack to vertical align the slider ...
                                                        sliderInput('threshold', '',
                                                                    min = 0.70, max = 0.99, value = 0.75, step = 0.01)
@@ -77,11 +76,11 @@ shinyUI(navbarPage(title = 'TargetNet',
                                        ),
                                        column(width = 2, offset = 0,
                                               tags$div(class = 'helpicon', # use this div as a wrapper for the next css hack to vertical align the help icon ...
-                                                       popHelp('Submit Single Query Compound', 'smiles', includeMD('help/smiles.md')),
+                                                       actionButton("smiles", "", icon = icon("circle-question"), class = "btn btn-link"),
                                                        HTML('&nbsp;&nbsp;&nbsp;&nbsp;'),
                                                        HTML('<a href="draw/index.html" target = "_blank"><span style="color:#666666"><i title="Draw a Molecule" class="fa fa-pencil" data-toggle="modal"></i></span></a>')
                                               ),
-                                              tags$style(type = 'text/css', 'div.helpicon { padding-top:40px; }')
+                                              tags$style(type = 'text/css', '.helpicon { padding-top:40px; } .helpicon .btn, .helpicon .btn:focus { color: #666666; background: none; border: none; }')
                                        )
                                      )
                               )
@@ -95,24 +94,19 @@ shinyUI(navbarPage(title = 'TargetNet',
                               h2(tags$strong('Upload SMILES or SDF File')),
                               hr(),
 
-                              fluidRow(
-                                column(
-                                  width = 12,
-                                  fileInput(inputId = 'file1',
-                                            label = 'Netting targets for one or more compounds stored in a SMILES or SDF file.',
-                                            accept = c('chemical/x-daylight-smiles',
-                                                       'chemical/x-mdl-sdfile',
-                                                       '.smi', '.SMI',
-                                                       '.smile', '.SMILE',
-                                                       '.smiles', '.SMILES',
-                                                       '.sd', '.SD',
-                                                       '.sdf', '.SDF'),
-                                            width = "100%")
-                                )
-                              ),
+                              fileInput(inputId = 'file1',
+                                        label = 'Netting targets for one or more compounds stored in a SMILES or SDF file.',
+                                        accept = c('chemical/x-daylight-smiles',
+                                                   'chemical/x-mdl-sdfile',
+                                                   '.smi', '.SMI',
+                                                   '.smile', '.SMILE',
+                                                   '.smiles', '.SMILES',
+                                                   '.sd', '.SD',
+                                                   '.sdf', '.SDF'),
+                                        width = "100%"),
 
                               fluidRow(
-                                column(width = 5, offset = 0,
+                                column(width = 3, offset = 0,
                                        tags$div(class = 'longselectupload', # use this div as a wrapper for the next css hack to make the bottom space large enough when the options expand ...
                                                 selectInput('criterionupload', 'Include models with:',
                                                             c('AUC >=' = 'auc',
@@ -124,7 +118,7 @@ shinyUI(navbarPage(title = 'TargetNet',
                                        ),
                                        tags$style(type = 'text/css', 'div.longselectupload { margin-bottom:20px; }')
                                 ),
-                                column(width = 5, offset = 0,
+                                column(width = 3, offset = 0,
                                        tags$div(class = 'thresholdsliderupload', # use this div as a wrapper for the next css hack to vertical align the slider ...
                                                 sliderInput('thresholdupload', '',
                                                             min = 0.70, max = 0.99, value = 0.75, step = 0.01)
@@ -132,11 +126,11 @@ shinyUI(navbarPage(title = 'TargetNet',
                                 ),
                                 column(width = 2, offset = 0,
                                        tags$div(class = 'helpiconupload', # use this div as a wrapper for the next css hack to vertical align the help icon ...
-                                                popHelp('Upload Query Compounds', 'uploadfile', includeMD('help/upload.md')),
+                                                actionButton("uploadfile", "", icon = icon("circle-question"), class = "btn btn-link"),
                                                 HTML('&nbsp;&nbsp;&nbsp;&nbsp;'),
                                                 HTML('<a href="draw/index.html" target = "_blank"><span style="color:#666666"><i title="Draw a Molecule" class="fa fa-pencil" data-toggle="modal"></i></span></a>')
                                        ),
-                                       tags$style(type = 'text/css', 'div.helpiconupload { padding-top:40px; }')
+                                       tags$style(type = 'text/css', '.helpiconupload { padding-top:40px; } .helpiconupload .btn, .helpiconupload .btn:focus { color: #666666; background: none; border: none; }')
                                 )
                               ),
 


### PR DESCRIPTION
The containers became too narrow because the HTML generated by `includeMD()` was problematic, perhaps due to {markdown} API changes. This PR restores the proper behavior by modifying the input arguments.

Also updates the popup button solution with the Shiny-native solution `modalDialog()`.

Now the UI look the same as before.